### PR TITLE
[TASK] Remove superfluous version check

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,20 +6,11 @@ use T3docs\BlogExample\Controller\BlogController;
 use T3docs\BlogExample\Controller\CommentController;
 use T3docs\BlogExample\Controller\PostController;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Information\Typo3Version;
 
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 (static function (string $extensionName): void {
-    $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-    // Only include page.tsconfig if TYPO3 version is below 12 so that it is not imported twice.
-    if ($versionInformation->getMajorVersion() < 12) {
-        ExtensionManagementUtility::addPageTSConfig('
-      @import "EXT:blog_example/Configuration/page.tsconfig"
-   ');
-    }
     /**
      * Configure the Plugin to call the
      * right combination of Controller and Action according to


### PR DESCRIPTION
As the current version of the extension needs at least TYPO3 v12 the check for older version can be removed safely.

Additionally, an unused "use" is dropped.