### PR TITLE
[CI] Update actions/checkout to version 4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Publish new version to TER
         uses: tomasnorre/typo3-upload-ter@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
    testsuite:
       name: All tests
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-latest
       strategy:
          matrix:
             php:
@@ -15,7 +15,7 @@ jobs:
                - '8.2'
       steps:
          - name: Checkout
-           uses: actions/checkout@v3
+           uses: actions/checkout@v4
 
          - name: Install testing system
            run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate


### PR DESCRIPTION
Additionally, use ubuntu-latest instead of a dedicated version to avoid outdated Ubuntu versions which are not supported anymore by GitHub in the future.

Releases: main, 12.4