### PR TITLE
[CI] Streamline tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,34 +1,43 @@
 name: tests
 
 on:
-   push:
-   pull_request:
+  push:
+  pull_request:
 
 jobs:
-   testsuite:
-      name: All tests
-      runs-on: ubuntu-latest
-      strategy:
-         matrix:
-            php:
-               - '8.1'
-               - '8.2'
-      steps:
-         - name: Checkout
-           uses: actions/checkout@v4
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - '8.1'
+          - '8.2'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-         - name: Install testing system
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
+      - name: Lint PHP
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
-         - name: Composer validate
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
+  code-quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    env:
+      php: '8.1'
 
-         - name: Composer normalize
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerNormalize -n
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-         - name: Lint PHP
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+      - name: Install testing system
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerUpdate
 
-         - name: CGL
-           if: ${{ matrix.php == '8.1' }}
-           run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
+      - name: Composer validate
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerValidate
+
+      - name: Composer normalize
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerNormalize -n
+
+      - name: CGL
+        run: Build/Scripts/runTests.sh -n -p ${{ env.php }} -s cgl


### PR DESCRIPTION
Separate linting (different PHP versions) with quality checks (one PHP version). The quality checks need only to run on one version.

This is now in line with the workflow from t3docs/examples.

Releases: main, 12.4