### PR TITLE
[TASK] Add return type to BackendController->initializeAction()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,21 +11,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Fixed
+- Add return type to `ModuleController->initializeAction()`
 
 ### Removed
 
 
 ## 12.0.2
 
-### Added
-
 ### Changed
 - The main branch was renamed from `master` to `main`
 
 ### Fixed
 - Fix `Services.yaml` for type converter example (#41)
-
-### Removed
 
 ## 12.0.1
 
@@ -34,7 +31,3 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Changed the vendor to t3docs (#40)
-
-### Fixed
-
-### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Fixed
-- Add return type to `ModuleController->initializeAction()`
+- Add return type to `ModuleController->initializeAction()` (#74)
 
 ### Removed
 

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -54,7 +54,7 @@ class BackendController extends ActionController
     /**
      * Function will be called before every other action
      */
-    protected function initializeAction()
+    protected function initializeAction(): void
     {
         $this->pageUid = (int)($this->request->getQueryParams()['id'] ?? 0);
         parent::initializeAction();


### PR DESCRIPTION
This is necessary to be compatible with TYPO3 v13.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/810
Releases: main