### PR TITLE
[FEATURE] Add page title provider for blog (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-## 12.0.5 - 2024-xx-xx
+## 12.1.0 - 2024-xx-xx
+
+### Added
+- Add page title provider for blog post indexAction and showAction (#43)
 
 ### Fixed
 - Update locallang_db.xlf - missing field names added (#76)

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -13,6 +13,7 @@ use T3docs\BlogExample\Domain\Repository\BlogRepository;
 use T3docs\BlogExample\Domain\Repository\PersonRepository;
 use T3docs\BlogExample\Domain\Repository\PostRepository;
 use T3docs\BlogExample\Exception\NoBlogAdminAccessException;
+use T3docs\BlogExample\PageTitle\BlogPageTitleProvider;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
@@ -48,7 +49,8 @@ class PostController extends \T3docs\BlogExample\Controller\AbstractController
         protected readonly BlogRepository $blogRepository,
         protected readonly PersonRepository $personRepository,
         protected readonly PostRepository $postRepository,
-        protected readonly PropertyMapper $propertyMapper
+        protected readonly PropertyMapper $propertyMapper,
+        protected readonly BlogPageTitleProvider $blogPageTitleProvider,
     ) {}
 
     /**
@@ -89,6 +91,7 @@ class PostController extends \T3docs\BlogExample\Controller\AbstractController
                 ->withExtensionName('blog_example')
                 ->withArguments(['currentPage' => $currentPage]);
         }
+        $this->blogPageTitleProvider->setTitle($blog->getTitle());
         if (empty($tag)) {
             $posts = $this->postRepository->findByBlog($blog);
         } else {
@@ -133,6 +136,7 @@ class PostController extends \T3docs\BlogExample\Controller\AbstractController
         Post $post,
         ?Comment $newComment = null
     ): ResponseInterface {
+        $this->blogPageTitleProvider->setTitle($post->getTitle());
         $this->view->assign('post', $post);
         $this->view->assign('newComment', $newComment);
         return $this->htmlResponse();

--- a/Classes/PageTitle/BlogPageTitleProvider.php
+++ b/Classes/PageTitle/BlogPageTitleProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3docs\BlogExample\PageTitle;
+
+use TYPO3\CMS\Core\PageTitle\AbstractPageTitleProvider;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * page title provider for blog post indexAction and showAction
+ */
+final class BlogPageTitleProvider extends AbstractPageTitleProvider
+{
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -50,3 +50,12 @@ module.tx_blogexample {
 
 lib.blog_example_post_list < tt_content.list.20.blogexample_postlist
 
+# Configure page title provider for blog post indexAction and showAction
+config {
+  pageTitleProviders {
+    blogExample {
+      provider = T3docs\BlogExample\PageTitle\BlogPageTitleProvider
+      before = record
+    }
+  }
+}


### PR DESCRIPTION
Add class BlogPageTitleProvider for use in the PostController. It outputs the title of the blog in the indexAction and the title of the post in the showAction.

Resolves: https://github.com/TYPO3-Documentation/blog_example/issues/43
Releases: main, 12.4