### PR TITLE
[BUGFIX] Invoke addFlashMessage() correctly when deleting a blog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 - Update locallang_db.xlf - missing field names added (#76)
 - Correct the integration of categories (#77)
-- Invoke addFlashMessage() correctly when deleting a post (#83)
+- Invoke addFlashMessage() correctly when deleting a post or a blog (#83, #86)
 
 ## 12.0.4 - 2023-09-16
 

--- a/Classes/Controller/BlogController.php
+++ b/Classes/Controller/BlogController.php
@@ -147,7 +147,7 @@ class BlogController extends AbstractController
     {
         $this->checkBlogAdminAccess();
         $this->blogRepository->remove($blog);
-        $this->addFlashMessage('deleted', ContextualFeedbackSeverity::INFO);
+        $this->addFlashMessage('The blog has been deleted.', 'deleted', ContextualFeedbackSeverity::INFO);
         return $this->redirect('index');
     }
 


### PR DESCRIPTION
Releases: main, 12.4