### PR TITLE
[BUGFIX] Catch error while retrieving extension settings

### DIFF
--- a/Classes/ExpressionLanguage/ExtensionConfigurationProvider.php
+++ b/Classes/ExpressionLanguage/ExtensionConfigurationProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace T3docs\BlogExample\ExpressionLanguage;
 
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\ExpressionLanguage\AbstractProvider;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -13,8 +15,11 @@ class ExtensionConfigurationProvider extends AbstractProvider
     public function __construct()
     {
         $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-        $this->expressionLanguageVariables = [
-            'blogConfiguration' => $configuration->get('blog_example'),
-        ];
+        try {
+            $this->expressionLanguageVariables = [
+                'blogConfiguration' => $configuration->get('blog_example'),
+            ];
+        } catch (ExtensionConfigurationExtensionNotConfiguredException | ExtensionConfigurationPathDoesNotExistException $e) {
+        }
     }
 }


### PR DESCRIPTION
While installing t3docs-code-snippets I got error: "No extension configuration for extension blog_example found".

Sure, there is no ext_conf_template.txt file for
blog_extension. But as we need the expression language file for documentation snippets we now wrap that lines with try-catch.

Relates: #103