### PR TITLE
Remove autoloader from ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,9 +16,4 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [],
         'suggests' => [],
     ],
-    'autoload' => [
-        'psr-4' => [
-            'T3docs\\BlogExample\\' => 'Classes/',
-        ],
-    ],
 ];


### PR DESCRIPTION
In TYPO3 the values from `ext_emconf.php` and `composer.json` will be joined. IMO they are called `Manifest` internally. So, it is not needed anymore to add autoloader information to `ext_emconf.php` since TYPO3 ~6.2.13.