### PR TITLE
Remove 'show' from page TSconfig as not evaluated anymore

### DIFF
--- a/Configuration/Sets/BlogExample/page.tsconfig
+++ b/Configuration/Sets/BlogExample/page.tsconfig
@@ -22,7 +22,5 @@ mod.wizards.newContentElement.wizardItems {
         }
       }
     }
-
-    show := addToList(blogexample_postlist,blogexample_postsingle,blogexample_blogadmin)
   }
 }


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html#impact

Nevertheless two of the listed plugins were invalid