### PR TITLE
Repair usage of FlexForm PluginSettings.xml

### DIFF
--- a/Classes/Controller/BlogController.php
+++ b/Classes/Controller/BlogController.php
@@ -54,7 +54,7 @@ class BlogController extends AbstractController
         $paginator = new QueryResultPaginator(
             $allAvailableBlogs,
             $currentPage,
-            3,
+            (int)($this->settings['itemsPerPage'] ?? 3),
         );
         $pagination = new SimplePagination($paginator);
         $this->view->assignMultiple([

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -103,7 +103,7 @@ class PostController extends AbstractController
         $paginator = new QueryResultPaginator(
             $posts,
             $currentPage,
-            (int)($this->settings['itemsPerPage'] ?? 3)
+            (int)($this->settings['itemsPerPage'] ?? 3),
         );
         $pagination = new SimplePagination($paginator);
         $this->view->assignMultiple([

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -100,7 +100,11 @@ class PostController extends AbstractController
             $posts = $this->postRepository->findByTagAndBlog($tag, $blog);
             $this->view->assign('tag', $tag);
         }
-        $paginator = new QueryResultPaginator($posts, $currentPage, 3);
+        $paginator = new QueryResultPaginator(
+            $posts,
+            $currentPage,
+            (int)($this->settings['itemsPerPage'] ?? 3)
+        );
         $pagination = new SimplePagination($paginator);
         $this->view->assignMultiple([
             'paginator' => $paginator,

--- a/Configuration/FlexForms/PluginSettings.xml
+++ b/Configuration/FlexForms/PluginSettings.xml
@@ -5,15 +5,14 @@
                 <sheetTitle>Options</sheetTitle>
                 <type>array</type>
                 <el>
-                    <settings.postsPerPage>
-                        <label>Max. number of posts to display per page
-                        </label>
+                    <settings.itemsPerPage>
+                        <label>Max. number of items to display per page</label>
                         <config>
                             <type>number</type>
                             <size>2</size>
                             <default>3</default>
                         </config>
-                    </settings.postsPerPage>
+                    </settings.itemsPerPage>
                 </el>
             </ROOT>
         </sDEF>

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -26,11 +26,11 @@ ExtensionUtility::registerPlugin(
     'blog_example_icon',
 );
 
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['blogexample_postlist']
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['blogexample_bloglist']
     = 'select_key';
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['blogexample_postlist']
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['blogexample_bloglist']
     = 'pi_flexform,recursive';
 ExtensionManagementUtility::addPiFlexFormValue(
-    'blogexample_postlist',
+    'blogexample_bloglist',
     'FILE:EXT:blog_example/Configuration/FlexForms/PluginSettings.xml',
 );


### PR DESCRIPTION
Merge 1st

Load FlexForm `PluginSettings.xml` if plugin `blogexample_bloglist` was selected. Previously it was only loaded on plugin `blogexample_postlist`, but that plugin seems to be removed in earlier patches.

Change `settings.postsPerPage` to `settings.itemsPerPage` as we have two paginators in blog_example. I don't want to create two items `blogsPerPage` and `postsPerPage` as I'm pretty sure that FlexForm is included in Docs as an example somewhere.

Make use and cast value of `settings.itemsPerPage` to int in `BlogController` and `PostController`, but keep 3 as default as fallback.