### PR TITLE
[BUGFIX] Use proper response file name paths

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -118,7 +118,7 @@ class BackendController extends ActionController
             'pages' => range(1, $pagination->getLastPageNumber()),
         ]);
 
-        return $view->renderResponse('Index');
+        return $view->renderResponse('Backend/Index');
     }
 
     /**
@@ -183,7 +183,7 @@ class BackendController extends ActionController
             'pages' => range(1, $pagination->getLastPageNumber()),
             'tag' => $tag,
         ]);
-        return $view->renderResponse('showBlog');
+        return $view->renderResponse('Backend/showBlog');
     }
 
     /**
@@ -193,7 +193,7 @@ class BackendController extends ActionController
     {
         $view = $this->initializeModuleTemplate($this->request);
         $view->assign('post', $post);
-        return $view->renderResponse('ShowPost');
+        return $view->renderResponse('Backend/ShowPost');
     }
 
     public function showAllCommentsAction(): ResponseInterface
@@ -201,7 +201,7 @@ class BackendController extends ActionController
         $view = $this->initializeModuleTemplate($this->request);
         $comments = $this->commentRepository->findAll();
         $view->assign('comments', $comments);
-        return $view->renderResponse('showAllComments');
+        return $view->renderResponse('Backend/showAllComments');
     }
 
     /**

--- a/ext_typoscript_constants.typoscript
+++ b/ext_typoscript_constants.typoscript
@@ -2,7 +2,7 @@
 module.tx_blogexample {
   view {
     # cat=module.tx_blogexample/file; type=string; label=Path to template root (BE)
-    templateRootPath = EXT:blog_example/Resources/Private/Backend/Templates/
+    templateRootPath = EXT:blog_example/Resources/Private/Templates/Backend/
     # cat=module.tx_blogexample/file; type=string; label=Path to template partials (BE)
     partialRootPath = EXT:blog_example/Resources/Private/Partials/
     # cat=module.tx_blogexample/file; type=string; label=Path to template layouts (BE)


### PR DESCRIPTION
The backend module is currently not functional and generates this error:
```
TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException

Tried resolving a template file for controller action "Default->Index" in format ".html", but none of the paths contained the expected template file (Default/Index.html). The following paths were checked: /var/www/html/vendor/typo3/cms-backend/Resources/Private/Templates/, /var/www/html/vendor/t3docs/blog-example/Resources/Private/Templates/ 
```
I tested the module in Typo3 13.4.